### PR TITLE
EPIB2B-907 : Modified  BillTo Service/Interface to use base service method to return response with Error message 

### DIFF
--- a/CommerceApiSDK/Services/BillToService.cs
+++ b/CommerceApiSDK/Services/BillToService.cs
@@ -58,8 +58,7 @@ namespace CommerceApiSDK.Services
             {
                 var url = CommerceAPIConstants.BillTosUrl;
                 var stringContent = await Task.Run(() => ServiceBase.SerializeModel(billTo));
-                ServiceResponse<BillTo> response;
-                response = await this.PostAsyncNoCacheWithErrorMessage<BillTo>(url, stringContent);
+                ServiceResponse<BillTo> response = await this.PostAsyncNoCacheWithErrorMessage<BillTo>(url, stringContent);
 
                 return response;
             }
@@ -103,8 +102,7 @@ namespace CommerceApiSDK.Services
             {
                 var url = BillToIdUrl(billToId);
                 var stringContent = await Task.Run(() => ServiceBase.SerializeModel(billTo));
-                ServiceResponse<BillTo> response;
-                response = await this.PatchAsyncNoCacheWithErrorMessage<BillTo>(url, stringContent);
+                ServiceResponse<BillTo> response = await this.PatchAsyncNoCacheWithErrorMessage<BillTo>(url, stringContent);
                 return response;
             }
             catch (Exception ex)
@@ -119,8 +117,7 @@ namespace CommerceApiSDK.Services
             try
             {
                 var stringContent = await Task.Run(() => ServiceBase.SerializeModel(billTo));
-                ServiceResponse<BillTo> response;
-                response = await this.PatchAsyncNoCacheWithErrorMessage<BillTo>(CommerceAPIConstants.BillToCurrentUrl, stringContent);
+                ServiceResponse<BillTo> response = await this.PatchAsyncNoCacheWithErrorMessage<BillTo>(CommerceAPIConstants.BillToCurrentUrl, stringContent);
                 return response;
             }
             catch (Exception ex)
@@ -206,8 +203,7 @@ namespace CommerceApiSDK.Services
             {
                 string url = ShipTosUrl(billToId);
                 StringContent stringContent = await Task.Run(() => SerializeModel(shipTo));
-                ServiceResponse<ShipTo> response;
-                response = await this.PostAsyncNoCacheWithErrorMessage<ShipTo>(url, stringContent);
+                ServiceResponse<ShipTo> response = await this.PostAsyncNoCacheWithErrorMessage<ShipTo>(url, stringContent);
                 return response;
             }
             catch (Exception ex)
@@ -222,8 +218,7 @@ namespace CommerceApiSDK.Services
             try
             {
                 StringContent stringContent = await Task.Run(() => SerializeModel(shipTo));
-                ServiceResponse<ShipTo> response;
-                response = await this.PostAsyncNoCacheWithErrorMessage<ShipTo>(CommerceAPIConstants.BillToCurrentShipTosUrl, stringContent);
+                ServiceResponse<ShipTo> response = await this.PostAsyncNoCacheWithErrorMessage<ShipTo>(CommerceAPIConstants.BillToCurrentShipTosUrl, stringContent);
                 return response;
             }
             catch (Exception ex)
@@ -268,8 +263,7 @@ namespace CommerceApiSDK.Services
             {
                 string url = ShipToIdUrl(billToId, shipToId);
                 var stringContent = await Task.Run(() => ServiceBase.SerializeModel(shipTo));
-                ServiceResponse<ShipTo> response;
-                response = await this.PatchAsyncNoCacheWithErrorMessage<ShipTo>(url, stringContent);
+                ServiceResponse<ShipTo> response = await this.PatchAsyncNoCacheWithErrorMessage<ShipTo>(url, stringContent);
                 return response;
             }
             catch (Exception ex)
@@ -284,8 +278,7 @@ namespace CommerceApiSDK.Services
             try
             {
                 var stringContent = await Task.Run(() => ServiceBase.SerializeModel(shipTo));
-                ServiceResponse<ShipTo> response;
-                response = await this.PatchAsyncNoCacheWithErrorMessage<ShipTo>(CommerceAPIConstants.BillToCurrentShipToCurrentUrl, stringContent);
+                ServiceResponse<ShipTo> response = await this.PatchAsyncNoCacheWithErrorMessage<ShipTo>(CommerceAPIConstants.BillToCurrentShipToCurrentUrl, stringContent);
                 return response;
             }
             catch (Exception ex)

--- a/CommerceApiSDK/Services/BillToService.cs
+++ b/CommerceApiSDK/Services/BillToService.cs
@@ -52,16 +52,16 @@ namespace CommerceApiSDK.Services
             }
         }
 
-        public async Task<BillTo> PostBillTosAsync(BillTo billTo)
+        public async Task<ServiceResponse<BillTo>> PostBillTosAsync(BillTo billTo)
         {
             try
             {
                 var url = CommerceAPIConstants.BillTosUrl;
                 var stringContent = await Task.Run(() => ServiceBase.SerializeModel(billTo));
+                ServiceResponse<BillTo> response;
+                response = await this.PostAsyncNoCacheWithErrorMessage<BillTo>(url, stringContent);
 
-                var result = await this.PostAsyncNoCache<BillTo>(url, stringContent);
-
-                return result;
+                return response;
             }
             catch (Exception ex)
             {
@@ -97,16 +97,15 @@ namespace CommerceApiSDK.Services
             }
         }
 
-        public async Task<BillTo> PatchBillTo(Guid billToId, BillTo billTo)
+        public async Task<ServiceResponse<BillTo>> PatchBillTo(Guid billToId, BillTo billTo)
         {
             try
             {
                 var url = BillToIdUrl(billToId);
                 var stringContent = await Task.Run(() => ServiceBase.SerializeModel(billTo));
-
-                var result = await this.PatchAsyncNoCache<BillTo>(url, stringContent);
-
-                return result;
+                ServiceResponse<BillTo> response;
+                response = await this.PatchAsyncNoCacheWithErrorMessage<BillTo>(url, stringContent);
+                return response;
             }
             catch (Exception ex)
             {
@@ -115,18 +114,14 @@ namespace CommerceApiSDK.Services
             }
         }
 
-        public async Task<BillTo> PatchCurrentBillTo(BillTo billTo)
+        public async Task<ServiceResponse<BillTo>> PatchCurrentBillTo(BillTo billTo)
         {
             try
             {
                 var stringContent = await Task.Run(() => ServiceBase.SerializeModel(billTo));
-
-                var result = await this.PatchAsyncNoCache<BillTo>(
-                    CommerceAPIConstants.BillToCurrentUrl,
-                    stringContent
-                );
-
-                return result;
+                ServiceResponse<BillTo> response;
+                response = await this.PatchAsyncNoCacheWithErrorMessage<BillTo>(CommerceAPIConstants.BillToCurrentUrl, stringContent);
+                return response;
             }
             catch (Exception ex)
             {
@@ -205,16 +200,15 @@ namespace CommerceApiSDK.Services
             }
         }
 
-        public async Task<ShipTo> PostShipToAsync(Guid billToId, ShipTo shipTo)
+        public async Task<ServiceResponse<ShipTo>> PostShipToAsync(Guid billToId, ShipTo shipTo)
         {
             try
             {
                 string url = ShipTosUrl(billToId);
                 StringContent stringContent = await Task.Run(() => SerializeModel(shipTo));
-
-                ShipTo result = await PostAsyncNoCache<ShipTo>(url, stringContent);
-
-                return result;
+                ServiceResponse<ShipTo> response;
+                response = await this.PostAsyncNoCacheWithErrorMessage<ShipTo>(url, stringContent);
+                return response;
             }
             catch (Exception ex)
             {
@@ -223,18 +217,14 @@ namespace CommerceApiSDK.Services
             }
         }
 
-        public async Task<ShipTo> PostCurrentBillToShipToAsync(ShipTo shipTo)
+        public async Task<ServiceResponse<ShipTo>> PostCurrentBillToShipToAsync(ShipTo shipTo)
         {
             try
             {
                 StringContent stringContent = await Task.Run(() => SerializeModel(shipTo));
-
-                ShipTo result = await PostAsyncNoCache<ShipTo>(
-                    CommerceAPIConstants.BillToCurrentShipTosUrl,
-                    stringContent
-                );
-
-                return result;
+                ServiceResponse<ShipTo> response;
+                response = await this.PostAsyncNoCacheWithErrorMessage<ShipTo>(CommerceAPIConstants.BillToCurrentShipTosUrl, stringContent);
+                return response;
             }
             catch (Exception ex)
             {
@@ -272,16 +262,15 @@ namespace CommerceApiSDK.Services
             }
         }
 
-        public async Task<ShipTo> PatchShipTo(Guid billToId, Guid shipToId, ShipTo shipTo)
+        public async Task<ServiceResponse<ShipTo>> PatchShipTo(Guid billToId, Guid shipToId, ShipTo shipTo)
         {
             try
             {
                 string url = ShipToIdUrl(billToId, shipToId);
                 var stringContent = await Task.Run(() => ServiceBase.SerializeModel(shipTo));
-
-                var result = await this.PatchAsyncNoCache<ShipTo>(url, stringContent);
-
-                return result;
+                ServiceResponse<ShipTo> response;
+                response = await this.PatchAsyncNoCacheWithErrorMessage<ShipTo>(url, stringContent);
+                return response;
             }
             catch (Exception ex)
             {
@@ -290,18 +279,14 @@ namespace CommerceApiSDK.Services
             }
         }
 
-        public async Task<ShipTo> PatchCurrentShipTo(ShipTo shipTo)
+        public async Task<ServiceResponse<ShipTo>> PatchCurrentShipTo(ShipTo shipTo)
         {
             try
             {
                 var stringContent = await Task.Run(() => ServiceBase.SerializeModel(shipTo));
-
-                var result = await this.PostAsyncNoCache<ShipTo>(
-                    CommerceAPIConstants.BillToCurrentShipToCurrentUrl,
-                    stringContent
-                );
-
-                return result;
+                ServiceResponse<ShipTo> response;
+                response = await this.PatchAsyncNoCacheWithErrorMessage<ShipTo>(CommerceAPIConstants.BillToCurrentShipToCurrentUrl, stringContent);
+                return response;
             }
             catch (Exception ex)
             {

--- a/CommerceApiSDK/Services/Interfaces/IBillToService.cs
+++ b/CommerceApiSDK/Services/Interfaces/IBillToService.cs
@@ -13,15 +13,14 @@ namespace CommerceApiSDK.Services.Interfaces
     {
         Task<GetBillTosResult> GetBillTosAsync(BillTosQueryParameters parameters = null);
 
-        Task<BillTo> PostBillTosAsync(BillTo billTo);
-
+        Task<ServiceResponse<BillTo>> PostBillTosAsync(BillTo billTo);
         Task<BillTo> GetBillTo(Guid billToId);
 
         Task<BillTo> GetCurrentBillTo();
 
-        Task<BillTo> PatchBillTo(Guid billToId, BillTo billTo);
+        Task<ServiceResponse<BillTo>> PatchBillTo(Guid billToId, BillTo billTo);
 
-        Task<BillTo> PatchCurrentBillTo(BillTo billTo);
+        Task<ServiceResponse<BillTo>> PatchCurrentBillTo(BillTo billTo);
 
         Task<GetShipTosResult> GetShipTosAsync(
             Guid billToId,
@@ -34,16 +33,16 @@ namespace CommerceApiSDK.Services.Interfaces
             ShipTosQueryParameters parameters = null
         );
 
-        Task<ShipTo> PostShipToAsync(Guid billToId, ShipTo shipTo);
+        Task<ServiceResponse<ShipTo>> PostShipToAsync(Guid billToId, ShipTo shipTo);
 
-        Task<ShipTo> PostCurrentBillToShipToAsync(ShipTo shipTo);
+        Task<ServiceResponse<ShipTo>> PostCurrentBillToShipToAsync(ShipTo shipTo);
 
         Task<ShipTo> GetShipTo(Guid billToId, Guid shipToId);
 
         Task<ShipTo> GetCurrentShipTo();
 
-        Task<ShipTo> PatchShipTo(Guid billToId, Guid shipToId, ShipTo shipTo);
+        Task<ServiceResponse<ShipTo>> PatchShipTo(Guid billToId, Guid shipToId, ShipTo shipTo);
 
-        Task<ShipTo> PatchCurrentShipTo(ShipTo shipTo);
+        Task<ServiceResponse<ShipTo>> PatchCurrentShipTo(ShipTo shipTo);
     }
 }


### PR DESCRIPTION
EPIB2B-907 : Modified BillTo Service related post/patch calls  to use base service method PostAsyncNoCacheWithErrorMessage/PatchAsyncNoCacheWithErrorMessage to capture error. Part of commerce SDK update.